### PR TITLE
Test of using labels for secret switch in _on_secret_changed

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -706,7 +706,7 @@ class TestCharm(unittest.TestCase):
         """NOTE: currently ops.testing seems to allow for non-leader to set secrets too!"""
         secret_id = self.harness.charm.set_secret(scope, "new-secret", "bla")
 
-        secret = self.harness.charm.model.get_secret(id=secret_id)
+        secret = self.harness.charm.model.get_secret(id=secret_id, label=f"{scope}_secret")
 
         event = mock.Mock()
         event.secret = secret


### PR DESCRIPTION
This is not tested, but is intended to show the general approach of using labels for this. I don't understand the scopes/keys part of this charm very well, so there might be more needed here.

This is similar to the code snippet [in our SDK docs](https://juju.is/docs/sdk/add-a-secret-to-a-charm#heading--label-secrets) showing an `_on_secret_changed` handler:

```python
class MyWebserverCharm(CharmBase):

    ...  # as before

    def _on_database_relation_changed(self, event: RelationChangedEvent):
        secret_id = event.relation.data[event.app]['secret-id']
        secret = self.model.get_secret(id=secret_id, label='database-secret')
        content = secret.get_content()
        self._configure_db_credentials(content['username'], content['password'])

    def _on_secret_changed(self, event):
        if event.secret.label == 'database-secret':
            content = event.secret.get_content(refresh=True)
            self._configure_db_credentials(content['username'], content['password'])
        elif event.secret.label == 'my-other-secret':
            self._handle_other_secret_changed(event.secret)
        else:
            pass  # ignore other labels (or log a warning)
```